### PR TITLE
for php5.5 curl_setopt_array() error

### DIFF
--- a/qiniu/io.php
+++ b/qiniu/io.php
@@ -47,7 +47,7 @@ function Qiniu_PutFile($upToken, $key, $localFile, $putExtra) // => ($putRet, $e
 		$putExtra = new Qiniu_PutExtra;
 	}
 
-	$fields = array('token' => $upToken, 'file' => '@' . $localFile);
+	$fields = array('token' => $upToken, 'file' => new \CURLFile($localFile));
 	if ($key === null) {
 		$fname = '?';
 	} else {


### PR DESCRIPTION
curl_setopt_array(): The usage of the @filename API for file uploading is deprecated. Please use the CURLFile class instead
