### PR TITLE
兼容openresty下header返回数据全部为小写，导致isJson函数判断直接返回false的问题

### DIFF
--- a/src/Qiniu/Http/Response.php
+++ b/src/Qiniu/Http/Response.php
@@ -170,6 +170,10 @@ final class Response
 
     private static function isJson($headers)
     {
+        if (isset($headers['content-type'])){
+            $headers['Content-Type'] = $headers['content-type'];
+        }
+
         return array_key_exists('Content-Type', $headers) &&
         strpos($headers['Content-Type'], 'application/json') === 0;
     }


### PR DESCRIPTION
七牛工单：https://support.qiniu.com/tickets/104822
Nginx：https://github.com/nginx/nginx/blob/master/src/http/v2/ngx_http_v2_table.c#L51
