### PR TITLE
Support GetRefreshList

### DIFF
--- a/examples/cdn_get_refresh_list.php
+++ b/examples/cdn_get_refresh_list.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once __DIR__ . '/../autoload.php';
+
+use Qiniu\Auth;
+use Qiniu\Cdn\CdnManager;
+
+// 控制台获取密钥：https://portal.qiniu.com/user/key
+$accessKey = getenv('QINIU_ACCESS_KEY');
+$secretKey = getenv('QINIU_SECRET_KEY');
+
+$auth = new Auth($accessKey, $secretKey);
+$cdnManager = new CdnManager($auth);
+
+// 获取CDN刷新查询
+// 参考文档：https://developer.qiniu.com/fusion/api/1229/cache-refresh
+
+//$params['requestId'] = ''; // 指定要查询记录所在的刷新请求id
+//$params['isDir'] = ''; // 指定是否查询目录，取值为 yes/no，默认不填则为两种类型记录都查询
+//$params['urls'] = array(); // 要查询的url列表，每个url可以是文件url，也可以是目录url
+$params['state'] = 'success'; // 指定要查询记录的状态，取值 processing／success／failure
+//$params['pageNo'] = 0; // 要求返回的页号，默认为0
+//$params['pageSize'] = 100; // 要求返回的页长度，默认为100
+//$params['startTime'] = ''; // 指定查询的开始日期，格式2006-01-01
+//$params['endTime'] = ''; // 指定查询的结束日期，格式2006-01-01
+
+list($refreshListResult, $refreshListErr) = $cdnManager->getCdnRefreshList($params);
+if ($refreshListErr !== null) {
+    var_dump($refreshListErr);
+} else {
+    echo 'query refresh list request sent';
+    print_r($refreshListResult);
+}
+

--- a/src/Qiniu/Cdn/CdnManager.php
+++ b/src/Qiniu/Cdn/CdnManager.php
@@ -145,6 +145,16 @@ final class CdnManager
         $body = json_encode($req);
         return $this->post($url, $body);
     }
+    /**
+     * @param array $params 查询CDN刷新参数
+     * @return array 参考 examples/cdn_get_refresh_list.php 代码
+     */
+    public function getCdnRefreshList($params = array())
+    {
+        $url = $this->server . '/v2/tune/refresh/list';
+        $body = json_encode($params);
+        return $this->post($url, $body);
+    }
 
     private function post($url, $body)
     {

--- a/tests/Qiniu/Tests/CdnManagerTest.php
+++ b/tests/Qiniu/Tests/CdnManagerTest.php
@@ -112,6 +112,15 @@ class CdnManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertNotNull($err);
     }
 
+    public function testGetCdnRefreshList()
+    {
+        $params['state'] = 'success'; // 指定要查询记录的状态，取值 processing／success／failure
+
+        list($ret, $err) = $this->cdnManager->getCdnRefreshList($params);
+        $this->assertNotNull($ret);
+        $this->assertNull($err);
+    }
+
     public function testCreateTimestampAntiLeechUrl()
     {
         $signUrl = $this->cdnManager->createTimestampAntiLeechUrl($this->refreshUrl, $this->encryptKey, 3600);


### PR DESCRIPTION
See issue: https://github.com/qiniu/php-sdk/issues/342#issue-698984201

## 缓存查询逻辑没有提供 

你好，src/Qiniu/Cdn/CdnManager.php类提供了缓存的刷新，却没有提供缓存刷新查询的逻辑实现。

由于刷新缓存是异步操作，在提交刷新CDN缓存的请求后返回的 200，并不意味着CDN缓存已经刷新成功，当然也是可以通过bucket发送对应的事件到指定地址，但如果有多个bucket的话，都要设置一遍会比较麻烦。

建议添加一个缓存刷新查询日志，可以清晰的列出提交刷新CND缓存的情况。

接口地址

/v2/tune/refresh/list

详见这里：https://developer.qiniu.com/fusion/api/1229/cache-refresh