### PR TITLE
Update Region.php

### DIFF
--- a/src/Qiniu/Region.php
+++ b/src/Qiniu/Region.php
@@ -146,7 +146,7 @@ class Region
         $url = Config::API_HOST . '/v2/query' . "?ak=$ak&bucket=$bucket";
         $ret = Client::Get($url);
         if (!$ret->ok()) {
-            return array(null, new Error($url, $ret));
+            throw new \Exception($ret->body);
         }
         $r = ($ret->body === null) ? array() : $ret->json();
         //parse Region;


### PR DESCRIPTION
获取 Region 的时候 如果返回错误 return 的是一个array 里面包含Error 但是上层调用的时候没有做处理，导致报错，并且错误信息并不能描述出问题出在哪里。
```
//vendor/qiniu/php-sdk/src/Qiniu/Config.php
private function getRegion($accessKey, $bucket)
    {
        $cacheId = "$accessKey:$bucket";

        if (isset($this->regionCache[$cacheId])) {
            $region = $this->regionCache[$cacheId];
        } elseif (isset($this->zone)) {
            $region = $this->zone;
            $this->regionCache[$cacheId] = $region;
        } else {
            /*******这里处理的时候没有考虑到异常的情况，所以$region 是一个数组， 上层调用的时候会报错***/
            $region = Zone::queryZone($accessKey, $bucket);
            $this->regionCache[$cacheId] = $region;
        }
        return $region;
    }
```