### PR TITLE
分片上传的版本号使用枚举判断，并添加单元测试覆盖错误版本号

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( file_exists(dirname(__FILE__).'/vendor/autoload.php') ) {
+    require_once dirname(__FILE__).'/vendor/autoload.php';
+}
+
 function classLoader($class)
 {
     $path = str_replace('\\', DIRECTORY_SEPARATOR, $class);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "myclabs/php-enum": "1.6.6"
     },
     "require-dev": {
         "paragonie/random_compat": ">=2",

--- a/src/Qiniu/Enum/QiniuEnum.php
+++ b/src/Qiniu/Enum/QiniuEnum.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Qiniu\Enum;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * 扩展 MyCLabs\Enum\Enum 以使用其新版本的 from 方法
+ *
+ * @link https://github.com/myclabs/php-enum
+ */
+abstract class QiniuEnum extends Enum
+{
+    /**
+     * @param mixed $value
+     * @return static
+     */
+    public static function from($value)
+    {
+        $key = self::assertValidValueReturningKey($value);
+
+        return self::__callStatic($key, array());
+    }
+
+    /**
+     * Asserts valid enum value
+     *
+     * @psalm-pure
+     * @psalm-assert T $value
+     * @param mixed $value
+     * @return string
+     */
+    private static function assertValidValueReturningKey($value)
+    {
+        if (false === ($key = self::search($value))) {
+            throw new \UnexpectedValueException("Value '$value' is not part of the enum " . __CLASS__);
+        }
+
+        return $key;
+    }
+}

--- a/src/Qiniu/Enum/SplitUploadVersion.php
+++ b/src/Qiniu/Enum/SplitUploadVersion.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Qiniu\Enum;
+
+final class SplitUploadVersion extends QiniuEnum
+{
+    const V1 = 'v1';
+    const V2 = 'v2';
+}


### PR DESCRIPTION
- 新增 `myclabs/php-enum` 包
- 新增枚举类 `SplitUploadVersion`
- 新增错误版本号 `v`, `1`, `2` 的单元测试

另外有几个注意点 Reviewers 可以看下：

1. ~~枚举类 `SplitUploadVersion` 按照当前项目风格（一个类一个文件），在 `src/Qiniu/Storage/ResumeUploader.php` 这个路径下。从分类的角度上看，与同级目录有点格格不入的感觉，不知有没有更好的建议；~~
    更改放入 `src/Qiniu/Enum/`
2. 在枚举类的加持下 `ResumeUploader->version` 若不合法就该类构造不出来，即 `ResumeUploader->version` 在运行时是安全的。但由于个人便好，仍在该类的方法中冗余了一部分判断逻辑来兜底。若觉得不必要可删除该部分代码。
    ``` php
    if ($this->version == SplitUploadVersion::V1) {
        // ...
    } elseif ($this->version == SplitUploadVersion::V2) {
        // ...
    } else { // 冗余的 `else`
        throw new \Exception("only support v1/v2 now!");
    }
    ```