### PR TITLE
make header key initial capital

### DIFF
--- a/src/Qiniu/Http/Client.php
+++ b/src/Qiniu/Http/Client.php
@@ -125,25 +125,10 @@ final class Client
         }
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-        $headers = self::parseHeaders(substr($result, 0, $header_size));
+        $headers = Header::parseRawText(substr($result, 0, $header_size));
         $body = substr($result, $header_size);
         curl_close($ch);
         return new Response($code, $duration, $headers, $body, null);
-    }
-
-    private static function parseHeaders($raw)
-    {
-        $headers = array();
-        $headerLines = explode("\r\n", $raw);
-        foreach ($headerLines as $line) {
-            $headerLine = trim($line);
-            $kv = explode(':', $headerLine);
-            if (count($kv) > 1) {
-                $kv[0] =self::ucwordsHyphen($kv[0]);
-                $headers[$kv[0]] = trim($kv[1]);
-            }
-        }
-        return $headers;
     }
 
     private static function escapeQuotes($str)
@@ -151,10 +136,5 @@ final class Client
         $find = array("\\", "\"");
         $replace = array("\\\\", "\\\"");
         return str_replace($find, $replace, $str);
-    }
-
-    private static function ucwordsHyphen($str)
-    {
-        return str_replace('- ', '-', ucwords(str_replace('-', '- ', $str)));
     }
 }

--- a/src/Qiniu/Http/Header.php
+++ b/src/Qiniu/Http/Header.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Qiniu\Http;
+
+/**
+ * field name case-insensitive Header
+ */
+class Header implements \ArrayAccess, \IteratorAggregate, \Countable
+{
+    /** @var array normalized key name map */
+    private $data;
+
+    /**
+     * @param array $obj non-normalized header object
+     */
+    public function __construct($obj = array())
+    {
+        foreach ($obj as $key => $values) {
+            $normalizedKey = self::normalizeKey($key);
+            $normalizedValues = array();
+            foreach ($values as $value) {
+                array_push($normalizedValues, self::normalizeValue($value));
+            }
+            $this->data[$normalizedKey] = $normalizedValues;
+        }
+        return $this;
+    }
+
+    /**
+     * return origin headers, which is field name case-sensitive
+     *
+     * @param string $raw
+     *
+     * @return array
+     */
+    public static function parseRawText($raw)
+    {
+        $headers = array();
+        $headerLines = explode("\r\n", $raw);
+        foreach ($headerLines as $line) {
+            $headerLine = trim($line);
+            $kv = explode(':', $headerLine);
+            if (count($kv) <= 1) {
+                continue;
+            }
+            // for http2 [Pseudo-Header Fields](https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.1)
+            if ($kv[0] == "") {
+                $fieldName = ":" . $kv[1];
+            } else {
+                $fieldName = $kv[0];
+            }
+            $fieldValue = trim(substr($headerLine, strlen($fieldName . ":")));
+            if (isset($headers[$fieldName])) {
+                array_push($headers[$fieldName], $fieldValue);
+            } else {
+                $headers[$fieldName] = array($fieldValue);
+            }
+        }
+        return $headers;
+    }
+
+    /**
+     * @param string $raw
+     *
+     * @return Header
+     */
+    public static function fromRawText($raw)
+    {
+        return new Header(self::parseRawText($raw));
+    }
+
+    /**
+     * @param string $key
+     *
+     * @return string
+     */
+    public static function normalizeKey($key)
+    {
+        $key = trim($key);
+
+        if (!self::isValidKeyName($key)) {
+            return $key;
+        }
+
+        return ucwords(strtolower($key), '-');
+    }
+
+    /**
+     * @param string|numeric $value
+     *
+     * @return string|numeric
+     */
+    public static function normalizeValue($value)
+    {
+        if (is_numeric($value)) {
+            return $value + 0;
+        }
+        return trim($value);
+    }
+
+    /**
+     * @return array
+     */
+    public function getRawData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param $offset string
+     *
+     * @return boolean
+     */
+    public function offsetExists($offset)
+    {
+        $key = self::normalizeKey($offset);
+        return isset($this->data[$key]);
+    }
+
+    /**
+     * @param $offset string
+     *
+     * @return string|null
+     */
+    public function offsetGet($offset)
+    {
+        $key = self::normalizeKey($offset);
+        if (isset($this->data[$key]) && count($this->data[$key])) {
+            return $this->data[$key][0];
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @param $offset string
+     * @param $value string
+     *
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        $key = self::normalizeKey($offset);
+        if (isset($this->data[$key]) && count($this->data[$key] > 0)) {
+            $this->data[$key][0] = self::normalizeValue($value);
+        } else {
+            $this->data[$key] = array(self::normalizeValue($value));
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        $key = self::normalizeKey($offset);
+        unset($this->data[$key]);
+    }
+
+    /**
+     * @return \ArrayIterator
+     */
+    public function getIterator()
+    {
+        $arr = array();
+        foreach ($this->data as $k => $v) {
+            $arr[$k] = $v[0];
+        }
+        return new \ArrayIterator($arr);
+    }
+
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->data);
+    }
+
+    private static $isTokenTable = array(
+        '!' => true,
+        '#' => true,
+        '$' => true,
+        '%' => true,
+        '&' => true,
+        '\'' => true,
+        '*' => true,
+        '+' => true,
+        '-' => true,
+        '.' => true,
+        '0' => true,
+        '1' => true,
+        '2' => true,
+        '3' => true,
+        '4' => true,
+        '5' => true,
+        '6' => true,
+        '7' => true,
+        '8' => true,
+        '9' => true,
+        'A' => true,
+        'B' => true,
+        'C' => true,
+        'D' => true,
+        'E' => true,
+        'F' => true,
+        'G' => true,
+        'H' => true,
+        'I' => true,
+        'J' => true,
+        'K' => true,
+        'L' => true,
+        'M' => true,
+        'N' => true,
+        'O' => true,
+        'P' => true,
+        'Q' => true,
+        'R' => true,
+        'S' => true,
+        'T' => true,
+        'U' => true,
+        'W' => true,
+        'V' => true,
+        'X' => true,
+        'Y' => true,
+        'Z' => true,
+        '^' => true,
+        '_' => true,
+        '`' => true,
+        'a' => true,
+        'b' => true,
+        'c' => true,
+        'd' => true,
+        'e' => true,
+        'f' => true,
+        'g' => true,
+        'h' => true,
+        'i' => true,
+        'j' => true,
+        'k' => true,
+        'l' => true,
+        'm' => true,
+        'n' => true,
+        'o' => true,
+        'p' => true,
+        'q' => true,
+        'r' => true,
+        's' => true,
+        't' => true,
+        'u' => true,
+        'v' => true,
+        'w' => true,
+        'x' => true,
+        'y' => true,
+        'z' => true,
+        '|' => true,
+        '~' => true,
+    );
+
+    /**
+     * @param string $str
+     *
+     * @return boolean
+     */
+    private static function isValidKeyName($str)
+    {
+        for ($i = 0; $i < count($str); $i += 1) {
+            if (!isset(self::$isTokenTable[$str[$i]])) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Qiniu/Http/Response.php
+++ b/src/Qiniu/Http/Response.php
@@ -8,7 +8,21 @@ namespace Qiniu\Http;
 final class Response
 {
     public $statusCode;
+    /**
+     * deprecated because of field names case-sensitive.
+     * use $normalizedHeaders instead which field names are case-insensitive.
+     * but be careful not to use $normalizedHeaders with `array_*` functions,
+     * such as `array_key_exists`, `array_keys`, `array_values`.
+     *
+     * use `isset` instead of `array_key_exists`,
+     * and should never use `array_key_exists` at http header.
+     *
+     * use `foreach` instead of `array_keys`, `array_values`.
+     *
+     * @deprecated
+     */
     public $headers;
+    public $normalizedHeaders;
     public $body;
     public $error;
     private $jsonData;
@@ -87,13 +101,23 @@ final class Response
     {
         $this->statusCode = $code;
         $this->duration = $duration;
-        $this->headers = $headers;
+        $this->headers = array();
         $this->body = $body;
         $this->error = $error;
         $this->jsonData = null;
+
         if ($error !== null) {
             return;
         }
+
+        foreach ($headers as $k => $vs) {
+            if (is_array($vs)) {
+                $this->headers[$k] = $vs[count($vs) - 1];
+            } else {
+                $this->headers[$k] = $vs;
+            }
+        }
+        $this->normalizedHeaders = new Header($headers);
 
         if ($body === null) {
             if ($code >= 400) {
@@ -101,7 +125,7 @@ final class Response
             }
             return;
         }
-        if (self::isJson($headers)) {
+        if (self::isJson($this->normalizedHeaders)) {
             try {
                 $jsonData = self::bodyJson($body);
                 if ($code >= 400) {
@@ -128,8 +152,11 @@ final class Response
         return $this->jsonData;
     }
 
-    public function headers()
+    public function headers($normalized = false)
     {
+        if ($normalized) {
+            return $this->normalizedHeaders;
+        }
         return $this->headers;
     }
 
@@ -145,24 +172,24 @@ final class Response
 
     public function xVia()
     {
-        $via = $this->headers['X-Via'];
+        $via = $this->normalizedHeaders['X-Via'];
         if ($via === null) {
-            $via = $this->headers['X-Px'];
+            $via = $this->normalizedHeaders['X-Px'];
         }
         if ($via === null) {
-            $via = $this->headers['Fw-Via'];
+            $via = $this->normalizedHeaders['Fw-Via'];
         }
         return $via;
     }
 
     public function xLog()
     {
-        return $this->headers['X-Log'];
+        return $this->normalizedHeaders['X-Log'];
     }
 
     public function xReqId()
     {
-        return $this->headers['X-Reqid'];
+        return $this->normalizedHeaders['X-Reqid'];
     }
 
     public function ok()
@@ -180,7 +207,6 @@ final class Response
 
     private static function isJson($headers)
     {
-        return array_key_exists('content-type', $headers) || array_key_exists('Content-Type', $headers) &&
-        strpos($headers['Content-Type'], 'application/json') === 0;
+        return isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'application/json') === 0;
     }
 }

--- a/tests/Qiniu/Tests/HeaderTest.php
+++ b/tests/Qiniu/Tests/HeaderTest.php
@@ -1,0 +1,153 @@
+<?php
+namespace Qiniu\Tests;
+
+use Qiniu\Http\Header;
+
+class HeaderTest extends \PHPUnit_Framework_TestCase
+{
+    protected $heads = array(
+        ':status' => array('200'),
+        ':x-test-1' => array('hello1'),
+        ':x-Test-2' => array('hello2'),
+        'content-type' => array('application/json'),
+        'CONTENT-LENGTH' => array(1234),
+        'oRiGin' => array('https://www.qiniu.com'),
+        'ReFer' => array('www.qiniu.com'),
+        'Last-Modified' => array('Mon, 06 Sep 2021 06:44:52 GMT'),
+        'acCePt-ChArsEt' => array('utf-8'),
+        'x-test-3' => array('hello3'),
+        'cache-control' => array('no-cache', 'no-store'),
+    );
+
+    public function testNormalizeKey()
+    {
+        $except = array(
+            ':status',
+            ':x-test-1',
+            ':x-Test-2',
+            'Content-Type',
+            'Content-Length',
+            'Origin',
+            'Refer',
+            'Last-Modified',
+            'Accept-Charset',
+            'X-Test-3',
+            'Cache-Control'
+        );
+        $actual = array_map(function ($str) {
+            return Header::normalizeKey($str);
+        }, array_keys($this->heads));
+        $this->assertEquals($actual, $except);
+    }
+
+    public function testGetRawData()
+    {
+        $header = new Header($this->heads);
+        foreach ($this->heads as $k => $v) {
+            $rawHeader = $header->getRawData();
+            $this->assertEquals($v, $rawHeader[Header::normalizeKey($k)]);
+        }
+    }
+
+    public function testOffsetExists()
+    {
+        $header = new Header($this->heads);
+        foreach (array_keys($this->heads) as $k) {
+            $this->assertNotNull($header[$k]);
+        }
+
+        $except = array(
+            ':status',
+            ':x-test-1',
+            ':x-Test-2',
+            'Content-Type',
+            'Content-Length',
+            'Origin',
+            'Refer',
+            'Last-Modified',
+            'Accept-Charset',
+            'X-Test-3',
+            'Cache-Control'
+        );
+        foreach ($except as $k) {
+            $this->assertNotNull($header[$k], $k." is null");
+        }
+    }
+
+    public function testOffsetGet()
+    {
+        $header = new Header($this->heads);
+        foreach ($this->heads as $k => $v) {
+            $this->assertEquals($v[0], $header[$k]);
+        }
+
+        $this->assertNull($header['no-exist']);
+    }
+
+    public function testOffsetSet()
+    {
+        $header = new Header($this->heads);
+        $header["X-Test-3"] = "hello";
+        $this->assertEquals("hello", $header["X-Test-3"]);
+        $header["x-test-3"] = "hello test3";
+        $this->assertEquals("hello test3", $header["x-test-3"]);
+        $header[":x-Test-2"] = "hello";
+        $this->assertEquals("hello", $header[":x-Test-2"]);
+        $header[":x-test-2"] = "hello test2";
+        $this->assertEquals("hello", $header[":x-Test-2"]);
+    }
+
+    public function testOffsetUnset()
+    {
+        $header = new Header($this->heads);
+        unset($header["X-Test-3"]);
+        $this->assertFalse(isset($header["X-Test-3"]));
+
+        $header = new Header($this->heads);
+        unset($header["x-test-3"]);
+        $this->assertFalse(isset($header["x-test-3"]));
+
+        $header = new Header($this->heads);
+        unset($header[":x-test-2"]);
+        $this->assertTrue(isset($header[":x-Test-2"]));
+
+        $header = new Header($this->heads);
+        unset($header[":x-Test-2"]);
+        $this->assertFalse(isset($header[":x-Test-2"]));
+    }
+
+    public function testGetIterator()
+    {
+        $header = new Header($this->heads);
+
+        $hasException = false;
+        try {
+            foreach ($header as $k => $v) {
+                $hasException = !isset($header[$k]);
+            }
+        } catch (\Exception $e) {
+            $hasException = true;
+        }
+        $this->assertFalse($hasException);
+    }
+
+    public function testCount()
+    {
+        $header = new Header($this->heads);
+
+        $this->assertEquals(count($this->heads), count($header));
+    }
+
+    public function testFromRaw()
+    {
+        $lines = array();
+        foreach ($this->heads as $k => $vs) {
+            foreach ($vs as $v) {
+                array_push($lines, $k . ": " . $v);
+            }
+        }
+        $raw = implode("\r\n", $lines);
+        $headerFromRaw = Header::fromRawText($raw);
+        $this->assertEquals(new Header($this->heads), $headerFromRaw);
+    }
+}


### PR DESCRIPTION
fix #371

同时：
- 修复 header 解析错误
- 新增通过大小写不敏感的名字获取 header 的方式，新增 `response->normalizedHeader`

以下为之前 header 解析错误的例子：

`:status: 200`
被解析为
`"" -> "status"`

`origin: https://www.qiniu.com`
被解析为
`"Origin" -> "https"`

`last-modified: Mon, 06 Sep 2021 06:44:52 GMT`
被解析为
`"Last-Modified" -> "Mon, 06 Sep 2021 06"`