### PR TITLE
php7.4环境下，count(字符串)产生错误

### DIFF
--- a/src/Qiniu/Auth.php
+++ b/src/Qiniu/Auth.php
@@ -114,7 +114,7 @@ final class Auth
 
         // append body
         $data .= "\n\n";
-        if (count($body) > 0
+        if (strlen($body) > 0
             && isset($headers["Content-Type"])
             && $headers["Content-Type"] != "application/octet-stream"
         ) {


### PR DESCRIPTION
php7.4环境下，count(字符串)产生

Warning: count(): Parameter must be an array or an object that implements Countable