### PR TITLE
fix using count to get string length

### DIFF
--- a/src/Qiniu/Auth.php
+++ b/src/Qiniu/Auth.php
@@ -114,7 +114,7 @@ final class Auth
 
         // append body
         $data .= "\n\n";
-        if (count($body) > 0
+        if (strlen($body) > 0
             && isset($headers["Content-Type"])
             && $headers["Content-Type"] != "application/octet-stream"
         ) {


### PR DESCRIPTION
> Warning: count(): Parameter must be an array or an object that implements Countable

fix warning under php 7.4