### PR TITLE
Remove Print

### DIFF
--- a/src/Qiniu/Storage/ArgusManager.php
+++ b/src/Qiniu/Storage/ArgusManager.php
@@ -84,7 +84,7 @@ final class ArgusManager
         $url = $scheme . Config::ARGUS_HOST . "/v3/jobs/video/$jobid";
         $response = $this->get($url);
         if (!$response->ok()) {
-            print("statusCode: " . $response->statusCode);
+            //print("statusCode: " . $response->statusCode);
             return array(null, new Error($url, $response));
         }
         return array($response->json(), null);
@@ -118,7 +118,7 @@ final class ArgusManager
         $headers['Content-Type'] = 'application/json';
         $ret = Client::post($url, $body, $headers, $this->proxy->makeReqOpt());
         if (!$ret->ok()) {
-            print("statusCode: " . $ret->statusCode);
+            //print("statusCode: " . $ret->statusCode);
             return array(null, new Error($url, $ret));
         }
         $r = ($ret->body === null) ? array() : $ret->json();


### PR DESCRIPTION
The existence of the print function might affect the final output of PHP. For example, if the final output is a JSON string, it could cause parsing failures on the client side.